### PR TITLE
support `report_metrics` for submodules

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ packages = find:
 #install_requires =
 #    six >= 1.10
 install_requires =
-    pytorch
+    torch
     transformers
 
 # Test dependencies, all dependencies for tests here. The format is align to install_requires.

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ packages = find:
 install_requires =
     torch
     transformers
+    accelerate
 
 # Test dependencies, all dependencies for tests here. The format is align to install_requires.
 # You can use the internal unittest, or the simplier framework such as pytest or nose.

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ name = hf-mtask-trainer
 author = zipzou
 # Project version, versions only above than 1.0 will assumed as a released version.
 # When modifying project version to above than 1.0, here's the rules should be followed.
-version = 0.0.1-alpha
+version = 0.0.2-alpha
 # A brief introduction about the project, ANY NON-ENGLISH CHARACTER IS NOT SUPPORTED!
 description = A HF Trainer Implementation for Multitask Training Logs
 # A longer version of introduction abouth the project, you can also include readme, change log, etc. .md or rst file is recommended.

--- a/test_trainer.py
+++ b/test_trainer.py
@@ -10,13 +10,28 @@ from transformers.training_args import TrainingArguments
 from hf_mtask_trainer import HfMultiTaskTrainer
 
 
-class TestModel(nn.Module):
+class TestSubModule(nn.Module):
+    supports_report_metrics: bool = True  # this is important in the future
 
     def __init__(self, ) -> None:
         super().__init__()
+
+    def forward(self):
+        self.report_metrics(constant=1.0)
+
+
+class TestModel(nn.Module):
+    supports_report_metrics: bool = True  # this is important in the future
+
+    def __init__(self, ) -> None:
+        super().__init__()
+        # add a submodule
+        self.submodule = TestSubModule()
         self.scaler = nn.Parameter(torch.ones(1))
 
     def forward(self, x):
+        # call submodule and report metrics
+        self.submodule()
         test_tensor = x + self.scaler
         test_np = np.array(np.random.randn()).astype(np.float32)
         test_int = random.randint(1, 100)


### PR DESCRIPTION
#1 A temporal implementation to support in submodules. Another flag `support_report_metrics` will be added and checked before patching in the future.
For #2  , I have updated the `setup.cfg` to resolve the dependency problem firstly as this package lightweight, but the `.toml` configuration would be applied if necessary in the future.
